### PR TITLE
Add anacron style has_been function

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,14 @@ The formats currently supported are
 - `*` (for wildcard),
 - and of course a single number.
 
-The module includes only one function, `is_now(s, dt=None)`, where `s` is the cron-style string
+The module includes `is_now(s, dt=None)`, where `s` is the cron-style string
 and `dt` is the datetime to use (defaults to current datetime, if not set).
 The function returns `True`, if `dt` matches the format.
+
+It also includes `has_been(s, since, dt=None)`, where `s` is the cron-style string, 
+`since` is a datetime in the past and `dt` is the datetime to use (defaults to current datetime, if not set).
+The function returns `True`, if `dt` would have matched the format at some point during the period. 
+This behaves much like like [anacron](https://en.wikipedia.org/wiki/Anacron) and is useful for applications which do not run continuously.
 
 There are couple of helpers available, mainly for use with Django.
 They give out list of tuples, as required by Django field choices.

--- a/pycron/__init__.py
+++ b/pycron/__init__.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 import calendar
 
 
@@ -65,3 +65,27 @@ def is_now(s, dt=None):
         and _parse_arg(dom, dt.day) \
         and _parse_arg(month, dt.month) \
         and _parse_arg(dow, 0 if weekday == 7 else weekday)
+
+
+def has_been(s, since, dt=None):
+    '''
+    A parser to check whether a (cron-like) string has been true during a certain time period. 
+    Useful for applications which cannot check every minute or need to catch up during a restart.
+    @input:
+        s = cron-like string (minute, hour, day of month, month, day of week)
+        since = datetime to use as reference time for start of period
+        dt = datetime to use as reference time for end of period, defaults to now
+    @output: boolean of result
+    '''
+    if dt is None:
+        dt = datetime.now()
+
+    if dt < since:
+        raise ValueError("The since datetime must be before the current datetime.")
+
+    while since <= dt:
+        if is_now(s, since):
+            return True
+        since += timedelta(minutes=1)
+    
+    return False

--- a/tests/test_has_been.py
+++ b/tests/test_has_been.py
@@ -1,0 +1,45 @@
+from datetime import datetime
+from nose.tools import assert_raises
+import pycron
+
+
+def test_minutes():
+    since = datetime(2015, 6, 18, 0, 1)
+    now = datetime(2015, 6, 18, 0, 3)
+
+    assert pycron.has_been('* * * * *', since, now)
+    assert pycron.has_been('0 * * * *', since, now) is False
+    assert pycron.has_been('1 * * * *', since, now)
+    assert pycron.has_been('2 * * * *', since, now)
+    assert pycron.has_been('3 * * * *', since, now)
+    assert pycron.has_been('4 * * * *', since, now) is False
+
+
+def test_hours():
+    since = datetime(2015, 6, 18, 1, 0)
+    now = datetime(2015, 6, 18, 3, 0)
+
+    assert pycron.has_been('* * * * *', since, now)
+    assert pycron.has_been('* 0 * * *', since, now) is False
+    assert pycron.has_been('* 1 * * *', since, now)
+    assert pycron.has_been('* 2 * * *', since, now)
+    assert pycron.has_been('* 3 * * *', since, now)
+    assert pycron.has_been('* 4 * * *', since, now) is False
+
+
+def test_days():
+    since = datetime(2015, 6, 1, 0, 0)
+    now = datetime(2015, 6, 3, 0, 0)
+
+    assert pycron.has_been('* * * * *', since, now)
+    assert pycron.has_been('* * 0 * *', since, now) is False
+    assert pycron.has_been('* * 1 * *', since, now)
+    assert pycron.has_been('* * 2 * *', since, now)
+    assert pycron.has_been('* * 3 * *', since, now)
+    assert pycron.has_been('* * 4 * *', since, now) is False
+
+
+def test_raises():
+    since = datetime(2016, 6, 1, 0, 0)
+    now = datetime(2015, 6, 3, 0, 0)
+    assert_raises(ValueError, pycron.has_been, '* * * * *', since, now)


### PR DESCRIPTION
First I want to say thank you for this library. I use it in my project [opsdroid](https://github.com/opsdroid/opsdroid) and it's awesome.

One thing I think is missing is the ability to replay a time period and catch up on any missed cron timings. For example if you restart your server and the application is offline for a few minutes you may miss a check which would've been true. Similar to the functionality of [anacron](https://en.wikipedia.org/wiki/Anacron).

To remedy this I've added `has_been` which takes the usual `s` and `dt` args but also a `since` arg which is a `datetime` in the past for which you want to check if there has been any matching timings since then. It works by incrementing the `since` time by one minute and testing against `is_now` until it is `True` or catches up with `dt`.

I hope you think this is useful to add to the library!