### PR TITLE
Make has_been timezone aware

### DIFF
--- a/pycron/__init__.py
+++ b/pycron/__init__.py
@@ -78,7 +78,7 @@ def has_been(s, since, dt=None):
     @output: boolean of result
     '''
     if dt is None:
-        dt = datetime.now()
+        dt = datetime.now(tz=since.tzinfo)
 
     if dt < since:
         raise ValueError("The since datetime must be before the current datetime.")

--- a/tests/test_has_been.py
+++ b/tests/test_has_been.py
@@ -1,5 +1,6 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 from nose.tools import assert_raises
+from pytz import utc
 import pycron
 
 
@@ -43,3 +44,11 @@ def test_raises():
     since = datetime(2016, 6, 1, 0, 0)
     now = datetime(2015, 6, 3, 0, 0)
     assert_raises(ValueError, pycron.has_been, '* * * * *', since, now)
+
+
+def test_timezone():
+    since = datetime.now(tz=utc) - timedelta(hours=1)
+    now = datetime.now(tz=None)
+
+    assert pycron.has_been('* * * * *', since)
+    assert_raises(TypeError, pycron.has_been, '* * * * *', since, now)


### PR DESCRIPTION
This PR ensures that if `dt` has to be created it has the same timezone as the `since` arg (or no timezone if that's the case).

I've added a test for this and also to test that it raises if both `dt` and `since` are provided but only one is timezone aware.

Fixes #3.