### PR TITLE
Add support for day names and abbreviations

### DIFF
--- a/pycron/__init__.py
+++ b/pycron/__init__.py
@@ -64,6 +64,9 @@ def _parse_arg(value, target, allow_daynames=False):
             # If target value is in the range, it matches
             if target in range(start, end + 1):
                 return True
+            # Special cases, where the day names are more or less incorrectly set...
+            if allow_daynames and start > end:
+                return target in range(start, end + 6 + 1)
 
     return False
 

--- a/pycron/__init__.py
+++ b/pycron/__init__.py
@@ -1,16 +1,34 @@
 from datetime import datetime, timedelta
 import calendar
 
-
+DAY_NAMES = [x.lower() for x in calendar.day_name[6:] + calendar.day_name[:6]]
+DAY_ABBRS = [x.lower() for x in calendar.day_abbr[6:] + calendar.day_abbr[:6]]
 # Choice tuples, mainly designed to use with Django
 MINUTE_CHOICES = [(str(x), str(x)) for x in range(0, 60)]
 HOUR_CHOICES = [(str(x), str(x)) for x in range(0, 24)]
 DOM_CHOICES = [(str(x), str(x)) for x in range(1, 32)]
 MONTH_CHOICES = [(str(x), calendar.month_name[x]) for x in range(1, 13)]
-DOW_CHOICES = [('0', calendar.day_name[6])] + [(str(x + 1), calendar.day_name[x]) for x in range(0, 6)]
+DOW_CHOICES = [(str(i), day_name) for i, day_name in enumerate(DAY_NAMES)]
 
 
-def _parse_arg(value, target):
+def _to_int(value, allow_daynames=False):
+    try:
+        return int(value)
+    except ValueError:
+        if not allow_daynames:
+            raise
+
+    for i, day_name in enumerate(DAY_NAMES):
+        if day_name == value:
+            return i
+    for i, day_abbr in enumerate(DAY_ABBRS):
+        if day_abbr == value:
+            return i
+
+    raise ValueError('Failed to parse string to integer')
+
+
+def _parse_arg(value, target, allow_daynames=False):
     value = value.strip()
 
     if value == '*':
@@ -21,7 +39,7 @@ def _parse_arg(value, target):
     for value in values:
         try:
             # First, try a direct comparison
-            if int(value) == target:
+            if _to_int(value, allow_daynames=allow_daynames) == target:
                 return True
         except ValueError:
             pass
@@ -32,12 +50,15 @@ def _parse_arg(value, target):
             if v != '*':
                 continue
             # If the remainder is zero, this matches
-            if target % int(interval) == 0:
+            if target % _to_int(interval, allow_daynames=allow_daynames) == 0:
                 return True
 
         if '-' in value:
             try:
-                start, end = [int(x.strip()) for x in value.split('-')]
+                start, end = [
+                    _to_int(x.strip(), allow_daynames=allow_daynames)
+                    for x in value.split('-')
+                ]
             except ValueError:
                 continue
             # If target value is in the range, it matches
@@ -64,7 +85,7 @@ def is_now(s, dt=None):
         and _parse_arg(hour, dt.hour) \
         and _parse_arg(dom, dt.day) \
         and _parse_arg(month, dt.month) \
-        and _parse_arg(dow, 0 if weekday == 7 else weekday)
+        and _parse_arg(dow, 0 if weekday == 7 else weekday, True)
 
 
 def has_been(s, since, dt=None):

--- a/tests/test_day_names.py
+++ b/tests/test_day_names.py
@@ -49,27 +49,36 @@ def test_day_names():
     run(Delorean(datetime=now, timezone='UTC').datetime)
 
 
-# def test_day_matching():
-#     def run(now):
-#         for i in range(0, 7):
-#             # Test day matching from Sunday onwards...
-#             now += timedelta(days=1)
-#             assert pycron.is_now('* * * * %i' % (i), now)
-#             # Test weekdays
-#             assert pycron.is_now('* * * * 1,2,3,4,5',
-#                                  now) is (True if i not in [0, 6] else False)
-#             assert pycron.is_now(
-#                 '* * * * 1-5', now) is (True if i not in [0, 6] else False)
-#             assert pycron.is_now('* * * * 1,2,3,4-5',
-#                                  now) is (True if i not in [0, 6] else False)
-#             # Test weekends
-#             assert pycron.is_now(
-#                 '* * * * 0,6', now) is (True if i in [0, 6] else False)
+def test_day_matching():
+    def run(now):
+        for i in range(0, 7):
+            # Test day matching from Sunday onwards...
+            now += timedelta(days=1)
+            assert pycron.is_now('* * * * %s' % (pycron.DAY_NAMES[i]), now)
+            assert pycron.is_now('* * * * %s' % (pycron.DAY_ABBRS[i]), now)
+            # Test weekdays
+            assert pycron.is_now('* * * * mon,tue,wed,thu,fri',
+                                 now) is (True if i not in [0, 6] else False)
+            assert pycron.is_now('* * * * monday,tuesday,wednesday,thursday,friday',
+                                 now) is (True if i not in [0, 6] else False)
+            assert pycron.is_now(
+                '* * * * mon-fri', now) is (True if i not in [0, 6] else False)
+            assert pycron.is_now(
+                '* * * * monday-friday', now) is (True if i not in [0, 6] else False)
+            assert pycron.is_now('* * * * mon,tue,wed,thu-fri',
+                                 now) is (True if i not in [0, 6] else False)
+            assert pycron.is_now('* * * * monday,tuesday,wednesday,thursday-friday',
+                                 now) is (True if i not in [0, 6] else False)
+            # Test weekends
+            assert pycron.is_now(
+                '* * * * sun,sat', now) is (True if i in [0, 6] else False)
+            assert pycron.is_now(
+                '* * * * sunday,saturday', now) is (True if i in [0, 6] else False)
 
-#     now = datetime(2015, 6, 20, 16, 7)
-#     run(now)
-#     run(now.replace(tzinfo=utc))
-#     run(pendulum.instance(now))
-#     run(arrow.get(now))
-#     run(udatetime.from_string(now.isoformat()))
-#     run(Delorean(datetime=now, timezone='UTC').datetime)
+    now = datetime(2015, 6, 20, 16, 7)
+    run(now)
+    run(now.replace(tzinfo=utc))
+    run(pendulum.instance(now))
+    run(arrow.get(now))
+    run(udatetime.from_string(now.isoformat()))
+    run(Delorean(datetime=now, timezone='UTC').datetime)

--- a/tests/test_day_names.py
+++ b/tests/test_day_names.py
@@ -1,0 +1,64 @@
+from datetime import datetime, timedelta
+import pycron
+from pytz import utc
+import pendulum
+import arrow
+import udatetime
+from delorean import Delorean
+
+
+def test_day_names():
+    def run(now):
+        assert pycron.is_now('* * * * *', now)
+        assert pycron.is_now('* * * * thu', now)
+        assert pycron.is_now('* * * * thursday', now)
+        assert pycron.is_now('* * * * */thu', now)
+        assert pycron.is_now('* * * * */thursday', now)
+        assert pycron.is_now('* * * * sun,wed,thu', now)
+        assert pycron.is_now('* * * * sunday,wednesday,thursday', now)
+        assert pycron.is_now('* * * * wed', now) is False
+        assert pycron.is_now('* * * * wednesday', now) is False
+        assert pycron.is_now('* * * * */wed', now) is False
+        assert pycron.is_now('* * * * */wednesday', now) is False
+        assert pycron.is_now('* * * * sun,wed,sat', now) is False
+        assert pycron.is_now('* * * * sunday,wednesday,saturday', now) is False
+        assert pycron.DOW_CHOICES[now.isoweekday()][1] == 'thursday'
+        assert pycron.DOW_CHOICES[0][1] == 'sunday'
+        assert pycron.is_now('* * * * sun-thu', now)
+        assert pycron.is_now('* * * * sunday-thursday', now)
+        assert pycron.is_now('* * * * fri-sat', now) is False
+        assert pycron.is_now('* * * * friday-saturday', now) is False
+
+    now = datetime(2015, 6, 18, 16, 7)
+    run(now)
+    run(now.replace(tzinfo=utc))
+    run(pendulum.instance(now))
+    run(arrow.get(now))
+    run(udatetime.from_string(now.isoformat()))
+    run(Delorean(datetime=now, timezone='UTC').datetime)
+
+
+# def test_day_matching():
+#     def run(now):
+#         for i in range(0, 7):
+#             # Test day matching from Sunday onwards...
+#             now += timedelta(days=1)
+#             assert pycron.is_now('* * * * %i' % (i), now)
+#             # Test weekdays
+#             assert pycron.is_now('* * * * 1,2,3,4,5',
+#                                  now) is (True if i not in [0, 6] else False)
+#             assert pycron.is_now(
+#                 '* * * * 1-5', now) is (True if i not in [0, 6] else False)
+#             assert pycron.is_now('* * * * 1,2,3,4-5',
+#                                  now) is (True if i not in [0, 6] else False)
+#             # Test weekends
+#             assert pycron.is_now(
+#                 '* * * * 0,6', now) is (True if i in [0, 6] else False)
+
+#     now = datetime(2015, 6, 20, 16, 7)
+#     run(now)
+#     run(now.replace(tzinfo=utc))
+#     run(pendulum.instance(now))
+#     run(arrow.get(now))
+#     run(udatetime.from_string(now.isoformat()))
+#     run(Delorean(datetime=now, timezone='UTC').datetime)

--- a/tests/test_day_names.py
+++ b/tests/test_day_names.py
@@ -28,6 +28,17 @@ def test_day_names():
         assert pycron.is_now('* * * * sunday-thursday', now)
         assert pycron.is_now('* * * * fri-sat', now) is False
         assert pycron.is_now('* * * * friday-saturday', now) is False
+        # Special cases, where the day names are more or less incorrectly set...
+        assert pycron.is_now('* * * * thu-sun', now)
+        assert pycron.is_now('* * * * thursday-sunday', now)
+        assert pycron.is_now('* * * * wed-sun', now)
+        assert pycron.is_now('* * * * wednesday-sunday', now)
+        assert pycron.is_now('* * * * wed-mon', now)
+        assert pycron.is_now('* * * * wednesday-monday', now)
+        assert pycron.is_now('* * * * fri-sun', now) is False
+        assert pycron.is_now('* * * * friday-sunday', now) is False
+        assert pycron.is_now('* * * * fri-wed', now) is False
+        assert pycron.is_now('* * * * friday-wednesday', now) is False
 
     now = datetime(2015, 6, 18, 16, 7)
     run(now)

--- a/tests/test_dow.py
+++ b/tests/test_dow.py
@@ -16,8 +16,8 @@ def test_dow():
         assert pycron.is_now('* * * * 3', now) is False
         assert pycron.is_now('* * * * */3', now) is False
         assert pycron.is_now('* * * * 0,3,6', now) is False
-        assert pycron.DOW_CHOICES[now.isoweekday()][1] == 'Thursday'
-        assert pycron.DOW_CHOICES[0][1] == 'Sunday'
+        assert pycron.DOW_CHOICES[now.isoweekday()][1] == 'thursday'
+        assert pycron.DOW_CHOICES[0][1] == 'sunday'
         assert pycron.is_now('* * * * 0-4', now)
         assert pycron.is_now('* * * * 5-6', now) is False
 


### PR DESCRIPTION
This is in response to issue #12 

The first commit takes care of the issue discussed in issue. The additional commits are more or less making the system more bullet proof, such as user (like my self) assuming the first day of the week to be Monday instead of Sunday.