### PR TITLE
Update pycron version to 3.1.1 and metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,13 @@
 [tool.poetry]
 name = "pycron"
-version = "3.1.0"
+version = "3.1.1"
 description = "Simple cron-like parser, which determines if current datetime matches conditions."
-authors = ["Kimmo Huoman <kipenroskaposti@gmail.com>"]
+authors = ["Kimmo Huoman <kipenroskaposti+pycron@gmail.com>"]
 license = "MIT"
 readme = "README.md"
+homepage = "https://github.com/kipe/pycron"
+repository = "https://github.com/kipe/pycron"
+keywords = ["cron", "parser"]
 
 [tool.poetry.dependencies]
 python = ">=3.9,<3.13"


### PR DESCRIPTION
- Bump version from 3.1.0 to 3.1.1 in `pyproject.toml`.
- Update author email address to include `+pycron` suffix for better identification.
- Add homepage and repository URLs to the project metadata for easier accessibility.
- Include "cron" as a keyword for improved searchability.